### PR TITLE
refactor: use jQuery as a weak dependency (similar as Blaze)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ bootstrap-3-modal
 =================
 A Meteor package making it easy to use bootstrap 3 modals in Meteor.
 
+Installation
+-----
 **Note 1:** In order for this package to work, you must include bootstrap 3 in
 your meteor project. You can add bootstrap 3 to your project by adding the
 package `twbs:bootstrap`:
@@ -12,6 +14,13 @@ meteor add twbs:bootstrap
 
 This package does not include `twbs:bootstrap` automatically (in case you
 have included bootstrap 3 in another way).
+
+**Note 2:**
+This package has a weak dependency on jQuery (similar as Blaze),
+so you can add jQuery to your Meteor app `<head>` from a [CDN](https://code.jquery.com/) or a [Meteor package](https://atmospherejs.com/meteor/jquery):
+```
+meteor add jquery
+```
 
 Include this package with:
 

--- a/package.js
+++ b/package.js
@@ -6,18 +6,19 @@ Package.describe({
 })
 
 Package.onUse(function(api){
-	
+
 	api.versionsFrom('METEOR@1.0.3')
-	
+
 	api.use([
 		'templating',
-		'jquery'
 	], 'client')
-	
+
+	api.use('jquery', 'client', { weak: true });
+
 	api.addFiles([
 		'main.js'
 	], 'client')
-	
+
 	api.export('Modal', 'client')
-	
+
 })


### PR DESCRIPTION
Now we are able to add jQuery from CDN directly to <head>.
jQuery does not need to be part of the initial JS bundle (and users might have it cached already)